### PR TITLE
fix(Constants&ZkCuratorClient):Fix zookeeper connection timeout bug a…

### DIFF
--- a/rpc-common/src/main/java/com/foolrpc/rpc/common/constants/Constants.java
+++ b/rpc-common/src/main/java/com/foolrpc/rpc/common/constants/Constants.java
@@ -20,7 +20,7 @@ public interface Constants {
 
 	int ZOOKEEPER_SESSION_TIME_OUT = 60 * 1000;
 
-	int ZOOKEEPER_CONNECTION_TIMEOUT_MS = 3 * 1000;
+	int ZOOKEEPER_CONNECTION_TIMEOUT_MS = 20 * 1000;
 
 	Charset CHARSET = StandardCharsets.UTF_8;
 

--- a/rpc-registry/src/main/java/com/foolrpc/rpc/registry/zookeeper/ZkCuratorClient.java
+++ b/rpc-registry/src/main/java/com/foolrpc/rpc/registry/zookeeper/ZkCuratorClient.java
@@ -56,7 +56,7 @@ public class ZkCuratorClient {
 			client.start();
 			boolean connected = client.blockUntilConnected(config.getConnectionTimeout(), TimeUnit.MILLISECONDS);
 			if (!connected) {
-				throw new IllegalStateException("zookeeper try to connect fail");
+				throw new IllegalStateException("zookeeper try to connect fail.Try to increase the zookeeper connection timeout");
 			}
 		} catch (Exception e) {
 			throw new IllegalStateException(e.getMessage(), e);


### PR DESCRIPTION
zookeeper现在连接比较慢，不同电脑速度不同，Mac比Windows快很多。因此win的总是运行不成功，这里增加超时时间，并完善错误信息的抛出以更好的找出错误地方。