### PR TITLE
fix:fixed Zookeeper connection too slow's problem

### DIFF
--- a/rpc-common/src/main/java/com/foolrpc/rpc/common/exception/RemoteInvokeFailException.java
+++ b/rpc-common/src/main/java/com/foolrpc/rpc/common/exception/RemoteInvokeFailException.java
@@ -8,6 +8,6 @@ package com.foolrpc.rpc.common.exception;
  **/
 public class RemoteInvokeFailException extends IllegalStateException {
 	public RemoteInvokeFailException(String method, String message) {
-		super("fail to invoke " + method + " details: " + method);
+		super("fail to invoke " + method + " details: " + message);
 	}
 }

--- a/rpc-registry/src/main/java/com/foolrpc/rpc/registry/zookeeper/NotifyTarget.java
+++ b/rpc-registry/src/main/java/com/foolrpc/rpc/registry/zookeeper/NotifyTarget.java
@@ -1,7 +1,5 @@
 package com.foolrpc.rpc.registry.zookeeper;
 
-import org.apache.curator.framework.recipes.cache.ChildData;
-
 /**
  * TODO
  *
@@ -19,10 +17,10 @@ public interface NotifyTarget {
 	}
 
 	/**
-	 * TODO
+	 * 接受来自注册中心的事件通知
 	 *
-	 * @param type 时间类型
-	 * @param path 触发事件的结点对象
+	 * @param type 事件类型
+	 * @param path 触发事件的结点路径
 	 **/
 	void onReceiveRegistryEvent(EventType type,String path);
 }

--- a/rpc-registry/src/main/java/com/foolrpc/rpc/registry/zookeeper/WithConfigZookeeperFactory.java
+++ b/rpc-registry/src/main/java/com/foolrpc/rpc/registry/zookeeper/WithConfigZookeeperFactory.java
@@ -1,0 +1,26 @@
+package com.foolrpc.rpc.registry.zookeeper;
+
+import org.apache.curator.utils.ZookeeperFactory;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.client.ZKClientConfig;
+
+/**
+ * WithConfigZookeeperFactory
+ *
+ * @author luolinyuan
+ * @date 2022/5/23
+ **/
+public class WithConfigZookeeperFactory implements ZookeeperFactory {
+
+	ZKClientConfig config;
+
+	public WithConfigZookeeperFactory(ZKClientConfig config) {
+		this.config = config;
+	}
+
+	@Override
+	public ZooKeeper newZooKeeper(String connectString, int sessionTimeout, Watcher watcher, boolean canBeReadOnly) throws Exception {
+		return new ZooKeeper(connectString, sessionTimeout, watcher, canBeReadOnly, this.config);
+	}
+}


### PR DESCRIPTION
修复了Zookeeper连接过慢的问题
通过实现ZookeeperFactory接口自定义Factory传入ZkClientConfig
这样一来跳过了getHostName()的耗时操作