### PR TITLE
Fix:fix java.net.SocketException：Connection reset

### DIFF
--- a/rpc-client/src/main/java/com/foolrpc/rpc/client/impl/RandomTransportSelector.java
+++ b/rpc-client/src/main/java/com/foolrpc/rpc/client/impl/RandomTransportSelector.java
@@ -46,6 +46,7 @@ public class RandomTransportSelector implements TransportSelector {
 
 	@Override
 	public synchronized void release(TransportClient client) {
+		client.close();
 		clients.put(client.getUrl(), client);
 	}
 


### PR DESCRIPTION
连接使用后未释放会出现警告，详情见飞书链接